### PR TITLE
Fix wrong binary name

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 		"node": ">=10.16.0"
 	},
 	"bin": {
-		"brr": "index.js",
+		"brrr": "index.js",
 		"brotli": "index.js"
 	},
 	"dependencies": {


### PR DESCRIPTION
The docs and name all describe the name as `brrr` (three r's). The package.json bin field only lists two r's in the name. This fixes that issue.